### PR TITLE
Separate register routes for user registration and adding a new passkey

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,9 @@ There are 4 named routes that make everything work:
 
 `POST 'passkeys.register.start'` - registration route, accepts `email` or other field specified in your config. Credential request options is returned.
 
-`POST 'passkeys.register.verify'` - registration route, accepts passkey response. If the passkey registration passes and an user is currently logged in, the passkey will be added to the existing account, if no one is currently logged in, an account will be created from the username/email and any additional data specified in config and sent along with this request. If the passkey registration fails, an exception with additional information is thrown.
+`POST 'passkeys.register.new'` - registration route, accepts passkey response. If the passkey registration passes, a new user will be created and logged in. If the passkey registration fails, an exception with additional information is thrown.
+
+`POST 'passkeys.register.verify'` - registration route, accepts passkey response. If the passkey registration passes and an user is currently logged in, the passkey will be added to the existing account. If the passkey registration fails, an exception with additional information is thrown.
 
 ## JS Example
 Below is minimal example of how to use this package with js `@simplewebauthn/browser`.

--- a/routes/passkeys.php
+++ b/routes/passkeys.php
@@ -15,7 +15,7 @@ Route::group([
     // Registration...
     if (Features::enabled(Features::registration())) {
         Route::post('passkey/register/options', [RegistrationController::class, 'generateOptions'])->name('passkeys.register.start');
-        Route::post('passkey/register', [RegistrationController::class, 'verify'])->name('passkeys.register.verify');
+        Route::post('passkey/register', [RegistrationController::class, 'registerNewUser'])->name('passkeys.register.new');
+        Route::post('passkey/register/add', [RegistrationController::class, 'verify'])->name('passkeys.register.verify');
     }
 });
-


### PR DESCRIPTION
Separate the register routes for user registration and adding a new passkey to a logged-in user.

* **routes/passkeys.php**
  - Add a new route `passkeys.register.new` for user registration.
  - Update the existing `passkeys.register` route to only handle adding a new passkey.

* **src/Controllers/RegistrationController.php**
  - Add a new method `registerNewUser` to handle user registration.
  - Update the `verify` method to only handle adding a new passkey to a logged-in user.

* **readme.md**
  - Update the documentation to reflect the new routes and their functionalities.

