### PR TITLE
Refactor passkey controllers to remove code duplication

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,3 +177,36 @@ function addPasskey() {
         });
 }
 ```
+
+## Refactoring
+
+The code has been refactored to reduce duplication and follow Laravel best practices. A new service class `PasskeyService` has been created to handle common logic for generating options and verifying responses. The `generateOptions` and `verify` methods in `AddPasskeyController`, `RegistrationController`, and `AuthenticationController` have been refactored to use `PasskeyService`.
+
+### PasskeyService
+
+The `PasskeyService` class is located in `src/Services/PasskeyService.php`. It contains the following methods:
+
+- `generateOptions(Request $request, $user = null): array` - Generates options for passkey creation.
+- `verify(Request $request, ServerRequestInterface $serverRequest, $user = null): array` - Verifies the passkey response.
+
+### Controllers
+
+The `generateOptions` and `verify` methods in the following controllers have been refactored to use `PasskeyService`:
+
+- `AddPasskeyController`
+- `RegistrationController`
+- `AuthenticationController`
+
+The `PasskeyService` is injected into the constructors of these controllers and used to handle the common logic for generating options and verifying responses.
+
+### Response Array
+
+The response has been updated to return an array with "verified". This change has been applied to the `verify` methods in the `AddPasskeyController`, `RegistrationController`, and `AuthenticationController`. The updated response is as follows:
+
+```php
+if ($response['verified']) {
+    return ['verified' => true];
+}
+
+return ['verified' => false];
+```

--- a/src/Controllers/AddPasskeyController.php
+++ b/src/Controllers/AddPasskeyController.php
@@ -2,108 +2,31 @@
 
 namespace Misakstvanu\LaravelFortifyPasskeys\Controllers;
 
-use Cose\Algorithms;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
-use Misakstvanu\LaravelFortifyPasskeys\CredentialSourceRepository;
+use Misakstvanu\LaravelFortifyPasskeys\Services\PasskeyService;
 use Psr\Http\Message\ServerRequestInterface;
 use Random\RandomException;
 use Throwable;
-use Webauthn\AttestationStatement\AttestationObjectLoader;
-use Webauthn\AttestationStatement\AttestationStatementSupportManager;
-use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
-use Webauthn\AuthenticationExtensions\AuthenticationExtensionsClientInputs;
-use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
-use Webauthn\AuthenticatorAttestationResponse;
-use Webauthn\AuthenticatorAttestationResponseValidator;
-use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\Exception\InvalidDataException;
-use Webauthn\PublicKeyCredentialCreationOptions;
-use Webauthn\PublicKeyCredentialLoader;
-use Webauthn\PublicKeyCredentialParameters;
-use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialUserEntity;
 
 class AddPasskeyController extends Controller {
 
-    const CREDENTIAL_CREATION_OPTIONS_SESSION_KEY = 'publicKeyCredentialCreationOptions';
+    protected PasskeyService $passkeyService;
+
+    public function __construct(PasskeyService $passkeyService)
+    {
+        $this->passkeyService = $passkeyService;
+    }
 
     /**
      * @throws RandomException
      */
     public function generateOptions(Request $request): array {
-        // Relying on Party Entity i.e. the application
-        $rpEntity = PublicKeyCredentialRpEntity::create(
-            config('app.name'),
-            parse_url(config('app.url'), PHP_URL_HOST),
-            null,
-        );
-
-        // User Entity
         $user = Auth::user();
-        $userEntity = PublicKeyCredentialUserEntity::create(
-            $user->email,
-            (string) $user->id,
-            $user->name,
-            null,
-        );
-
-        // Challenge (random binary string)
-        $challenge = random_bytes(16);
-
-        // List of supported public key parameters
-        $supportedPublicKeyParams = collect([
-            Algorithms::COSE_ALGORITHM_ES256,
-            Algorithms::COSE_ALGORITHM_ES256K,
-            Algorithms::COSE_ALGORITHM_ES384,
-            Algorithms::COSE_ALGORITHM_ES512,
-            Algorithms::COSE_ALGORITHM_RS256,
-            Algorithms::COSE_ALGORITHM_RS384,
-            Algorithms::COSE_ALGORITHM_RS512,
-            Algorithms::COSE_ALGORITHM_PS256,
-            Algorithms::COSE_ALGORITHM_PS384,
-            Algorithms::COSE_ALGORITHM_PS512,
-            Algorithms::COSE_ALGORITHM_ED256,
-            Algorithms::COSE_ALGORITHM_ED512,
-        ])->map(
-            fn($algorithm) => PublicKeyCredentialParameters::create('public-key', $algorithm)
-        )->toArray();
-
-        // Instantiate PublicKeyCredentialCreationOptions object
-        $pkCreationOptions =
-            PublicKeyCredentialCreationOptions::create(
-                $rpEntity,
-                $userEntity,
-                $challenge,
-                $supportedPublicKeyParams,
-                authenticatorSelection: AuthenticatorSelectionCriteria::create(),
-                attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
-                extensions: AuthenticationExtensionsClientInputs::createFromArray([
-                    'credProps' => true,
-                ])
-            );
-
-        $serializedOptions = $pkCreationOptions->jsonSerialize();
-
-        if (!isset($serializedOptions['excludeCredentials'])) {
-            // The JS side needs this, so let's set it up for success with an empty array
-            $serializedOptions['excludeCredentials'] = [];
-        }
-
-        // This library for some reason doesn't serialize the extensions object,
-        // so we'll do it manually
-        $serializedOptions['extensions'] = $serializedOptions['extensions']->jsonSerialize();
-
-        // It is important to store the user entity and the options object (e.g. in the session)
-        // for the next step. The data will be needed to check the response from the device.
-        $request->session()->flash(
-            self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY,
-            json_decode(json_encode($serializedOptions), true)
-        );
-
-        return $serializedOptions;
+        return $this->passkeyService->generateOptions($request, $user);
     }
 
     /**
@@ -111,61 +34,11 @@ class AddPasskeyController extends Controller {
      * @throws Throwable
      * @throws ValidationException
      */
-    public function verify(Request $request, ServerRequestInterface $serverRequest): array {
-        // A repo of our public key credentials
-        $pkSourceRepo = new CredentialSourceRepository();
-
-        $attestationManager = AttestationStatementSupportManager::create();
-        $attestationManager->add(NoneAttestationStatementSupport::create());
-
-        // The validator that will check the response from the device
-        $responseValidator = AuthenticatorAttestationResponseValidator::create(
-            $attestationManager,
-            $pkSourceRepo,
-            null,
-            ExtensionOutputCheckerHandler::create()
-        );
-
-        // A loader that will load the response from the device
-        $pkCredentialLoader = PublicKeyCredentialLoader::create(
-            AttestationObjectLoader::create($attestationManager)
-        );
-
-        $publicKeyCredential = $pkCredentialLoader->load(json_encode($request->all()));
-
-        $authenticatorAttestationResponse = $publicKeyCredential->response;
-
-        if (!$authenticatorAttestationResponse instanceof AuthenticatorAttestationResponse) {
-            throw ValidationException::withMessages([
-                config('passkeys.username_column') => 'Invalid response type',
-            ]);
-        }
-
-        // Check the response from the device, this will
-        // throw an exception if the response is invalid.
-        // For the purposes of this demo, we are letting
-        // the exception bubble up so we can see what is
-        // going on.
-        $publicKeyCredentialSource = $responseValidator->check(
-            $authenticatorAttestationResponse,
-            PublicKeyCredentialCreationOptions::createFromArray(
-                $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
-            ),
-            $serverRequest,
-            config('passkeys.relying_party_ids')
-        );
-
-        // If we've gotten this far, the response is valid!
-
-        // Save the public key credential source to the database
+    public function verify(Request $request, ServerRequestInterface $serverRequest) {
         $user = Auth::user();
-        $publicKeyCredentialSource->userHandle = $user->{config('passkeys.username_column')};
+        $response = $this->passkeyService->verify($request, $serverRequest, $user);
 
-        $pkSourceRepo->saveCredentialSource($publicKeyCredentialSource);
-
-        return [
-            'verified' => true,
-        ];
+        return $response;
     }
 
 }

--- a/src/Controllers/AddPasskeyController.php
+++ b/src/Controllers/AddPasskeyController.php
@@ -34,11 +34,10 @@ class AddPasskeyController extends Controller {
      * @throws Throwable
      * @throws ValidationException
      */
-    public function verify(Request $request, ServerRequestInterface $serverRequest) {
+    public function verify(Request $request, ServerRequestInterface $serverRequest): array
+    {
         $user = Auth::user();
-        $response = $this->passkeyService->verify($request, $serverRequest, $user);
-
-        return $response;
+        return $this->passkeyService->verify($request, $serverRequest, $user);
     }
 
 }

--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -2,12 +2,15 @@
 
 namespace Misakstvanu\LaravelFortifyPasskeys\Controllers;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
+use Misakstvanu\LaravelFortifyPasskeys\Requests\GenerateAuthenticationOptionsRequest;
 use Misakstvanu\LaravelFortifyPasskeys\Services\PasskeyService;
 use Psr\Http\Message\ServerRequestInterface;
+use Random\RandomException;
 use Throwable;
 use Webauthn\Exception\InvalidDataException;
 
@@ -22,6 +25,7 @@ class AuthenticationController extends Controller {
 
     /**
      * @throws ValidationException
+     * @throws RandomException
      * @throws RandomException
      */
     public function generateOptions(GenerateAuthenticationOptionsRequest $request): array {
@@ -39,7 +43,8 @@ class AuthenticationController extends Controller {
      * @throws Throwable
      * @throws ValidationException
      */
-    public function verify(Request $request, ServerRequestInterface $serverRequest) {
+    public function verify(Request $request, ServerRequestInterface $serverRequest): array
+    {
         $response = $this->passkeyService->verify($request, $serverRequest);
 
         if ($response['verified']) {

--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -2,49 +2,23 @@
 
 namespace Misakstvanu\LaravelFortifyPasskeys\Controllers;
 
-
-use App\Models\User;
-use Cose\Algorithm\Manager;
-use Cose\Algorithm\Signature\ECDSA\ES256;
-use Cose\Algorithm\Signature\ECDSA\ES256K;
-use Cose\Algorithm\Signature\ECDSA\ES384;
-use Cose\Algorithm\Signature\ECDSA\ES512;
-use Cose\Algorithm\Signature\EdDSA\Ed256;
-use Cose\Algorithm\Signature\EdDSA\Ed512;
-use Cose\Algorithm\Signature\RSA\PS256;
-use Cose\Algorithm\Signature\RSA\PS384;
-use Cose\Algorithm\Signature\RSA\PS512;
-use Cose\Algorithm\Signature\RSA\RS256;
-use Cose\Algorithm\Signature\RSA\RS384;
-use Cose\Algorithm\Signature\RSA\RS512;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
-use Misakstvanu\LaravelFortifyPasskeys\CredentialSourceRepository;
-use Misakstvanu\LaravelFortifyPasskeys\Requests\GenerateAuthenticationOptionsRequest;
+use Misakstvanu\LaravelFortifyPasskeys\Services\PasskeyService;
 use Psr\Http\Message\ServerRequestInterface;
-use Random\RandomException;
 use Throwable;
-use Webauthn\AttestationStatement\AttestationObjectLoader;
-use Webauthn\AttestationStatement\AttestationStatementSupportManager;
-use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
-use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
-use Webauthn\AuthenticatorAssertionResponse;
-use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\Exception\InvalidDataException;
-use Webauthn\PublicKeyCredentialDescriptor;
-use Webauthn\PublicKeyCredentialLoader;
-use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialSource;
-use Webauthn\PublicKeyCredentialUserEntity;
-use Webauthn\TokenBinding\IgnoreTokenBindingHandler;
 
 class AuthenticationController extends Controller {
 
-    // We use this key across several methods, so we're going to define it here
-    protected const CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY = 'publicKeyCredentialRequestOptions';
+    protected PasskeyService $passkeyService;
+
+    public function __construct(PasskeyService $passkeyService)
+    {
+        $this->passkeyService = $passkeyService;
+    }
 
     /**
      * @throws ValidationException
@@ -57,47 +31,7 @@ class AuthenticationController extends Controller {
             throw new ModelNotFoundException('User not found', 404, $e);
         }
 
-        // User Entity
-        $userEntity = PublicKeyCredentialUserEntity::create(
-            $user->email,
-            (string) $user->id,
-            $user->name,
-            null,
-        );
-
-        // A repo of our public key credentials
-        $pkSourceRepo = new CredentialSourceRepository();
-
-        // A user can have multiple authenticators, so we need to get all of them to check against
-        $registeredAuthenticators = $pkSourceRepo->findAllForUserEntity($userEntity);
-
-        // We don’t need the Credential Sources, just the associated Descriptors
-        $allowedCredentials = collect($registeredAuthenticators)
-            ->pluck('public_key')
-            ->map(
-                fn ($publicKey) => PublicKeyCredentialSource::createFromArray($publicKey)
-            )
-            ->map(
-                fn (PublicKeyCredentialSource $credential): PublicKeyCredentialDescriptor => $credential->getPublicKeyCredentialDescriptor()
-            )
-            ->toArray();
-
-        $pkRequestOptions =
-            PublicKeyCredentialRequestOptions::create(
-                random_bytes(32), // Challenge
-                allowCredentials: $allowedCredentials
-            );
-
-        $serializedOptions = $pkRequestOptions->jsonSerialize();
-
-        // It is important to store the the options object in the session
-        // for the next step. The data will be needed to check the response from the device.
-        $request->session()->flash(
-            self::CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY,
-            json_decode(json_encode($serializedOptions), true)
-        );
-
-        return $serializedOptions;
+        return $this->passkeyService->generateOptions($request, $user);
     }
 
     /**
@@ -105,79 +39,17 @@ class AuthenticationController extends Controller {
      * @throws Throwable
      * @throws ValidationException
      */
-    public function verify(Request $request, ServerRequestInterface $serverRequest): array {
-        // A repo of our public key credentials
-        $pkSourceRepo = new CredentialSourceRepository();
+    public function verify(Request $request, ServerRequestInterface $serverRequest) {
+        $response = $this->passkeyService->verify($request, $serverRequest);
 
-        $attestationManager = AttestationStatementSupportManager::create();
-        $attestationManager->add(NoneAttestationStatementSupport::create());
+        if ($response['verified']) {
+            $user = config('passkeys.user_model')::where(config('passkeys.username_column'), $response['userHandle'])->firstOrFail();
+            Auth::login($user);
 
-        $algorithmManager = Manager::create()->add(
-            ES256::create(),
-            ES256K::create(),
-            ES384::create(),
-            ES512::create(),
-            RS256::create(),
-            RS384::create(),
-            RS512::create(),
-            PS256::create(),
-            PS384::create(),
-            PS512::create(),
-            Ed256::create(),
-            Ed512::create(),
-        );
-
-        // The validator that will check the response from the device
-        $responseValidator = AuthenticatorAssertionResponseValidator::create(
-            $pkSourceRepo,
-            null,
-            ExtensionOutputCheckerHandler::create(),
-            $algorithmManager,
-        );
-
-        // A loader that will load the response from the device
-        $pkCredentialLoader = PublicKeyCredentialLoader::create(
-            AttestationObjectLoader::create($attestationManager)
-        );
-
-        $publicKeyCredential = $pkCredentialLoader->load(json_encode($request->all()));
-
-        $authenticatorAssertionResponse = $publicKeyCredential->response;
-
-        if(null === $userHandle = $authenticatorAssertionResponse?->userHandle)
-            $userHandle = $pkSourceRepo->findOneByCredentialId($publicKeyCredential->rawId)->userHandle;
-
-        if (!$authenticatorAssertionResponse instanceof AuthenticatorAssertionResponse) {
-            throw ValidationException::withMessages([
-                config('passkeys.username_column') => 'Invalid response type',
-            ]);
+            return ['verified' => true];
         }
 
-        // Check the response from the device, this will
-        // throw an exception if the response is invalid.
-        // For the purposes of this demo, we are letting
-        // the exception bubble up so we can see what is
-        // going on.
-        $publicKeyCredentialSource = $responseValidator->check(
-            $publicKeyCredential->rawId,
-            $authenticatorAssertionResponse,
-            PublicKeyCredentialRequestOptions::createFromArray(
-                $request->session()->get(self::CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY)
-            ),
-            $serverRequest,
-            $userHandle,
-            config('passkeys.relying_party_ids')
-        );
-
-        // If we've gotten this far, the response is valid!
-
-        $user = config('passkeys.user_model')::where(config('passkeys.username_column'), $publicKeyCredentialSource->userHandle)->firstOrFail();
-
-        Auth::login($user);
-
-        return [
-            'verified' => true,
-        ];
+        return ['verified' => false];
     }
 
 }

--- a/src/Controllers/RegistrationController.php
+++ b/src/Controllers/RegistrationController.php
@@ -33,7 +33,8 @@ class RegistrationController extends Controller {
      * @throws Throwable
      * @throws ValidationException
      */
-    public function verify(Request $request, ServerRequestInterface $serverRequest) {
+    public function verify(Request $request, ServerRequestInterface $serverRequest): array
+    {
         $userData = $request->validate(config('passkeys.registration_user_validation'));
 
         $response = $this->passkeyService->verify($request, $serverRequest);

--- a/src/Controllers/RegistrationController.php
+++ b/src/Controllers/RegistrationController.php
@@ -2,112 +2,30 @@
 
 namespace Misakstvanu\LaravelFortifyPasskeys\Controllers;
 
-use App\Models\User;
-use Cose\Algorithms;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
-use Misakstvanu\LaravelFortifyPasskeys\CredentialSourceRepository;
+use Misakstvanu\LaravelFortifyPasskeys\Services\PasskeyService;
 use Psr\Http\Message\ServerRequestInterface;
 use Random\RandomException;
 use Throwable;
-use Webauthn\AttestationStatement\AttestationObjectLoader;
-use Webauthn\AttestationStatement\AttestationStatementSupportManager;
-use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
-use Webauthn\AuthenticationExtensions\AuthenticationExtensionsClientInputs;
-use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
-use Webauthn\AuthenticatorAttestationResponse;
-use Webauthn\AuthenticatorAttestationResponseValidator;
-use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\Exception\InvalidDataException;
-use Webauthn\PublicKeyCredentialCreationOptions;
-use Webauthn\PublicKeyCredentialLoader;
-use Webauthn\PublicKeyCredentialParameters;
-use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialUserEntity;
 
 class RegistrationController extends Controller {
 
-    // We use this key across several methods, so we're going to define it here
-    const CREDENTIAL_CREATION_OPTIONS_SESSION_KEY = 'publicKeyCredentialCreationOptions';
+    protected PasskeyService $passkeyService;
+
+    public function __construct(PasskeyService $passkeyService)
+    {
+        $this->passkeyService = $passkeyService;
+    }
 
     /**
      * @throws RandomException
      */
     public function generateOptions(Request $request): array {
-        // Relying on Party Entity i.e. the application
-        $rpEntity = PublicKeyCredentialRpEntity::create(
-            config('app.name'),
-            parse_url(config('app.url'), PHP_URL_HOST),
-            null,
-        );
-
-        // User Entity
-        $userEntity = PublicKeyCredentialUserEntity::create(
-            $request->input(config('passkeys.username_column')),
-            $request->input(config('passkeys.username_column')),
-            $request->input(config('passkeys.username_column')),
-            null,
-        );
-
-        // Challenge (random binary string)
-        $challenge = random_bytes(16);
-
-        // List of supported public key parameters
-        $supportedPublicKeyParams = collect([
-            Algorithms::COSE_ALGORITHM_ES256,
-            Algorithms::COSE_ALGORITHM_ES256K,
-            Algorithms::COSE_ALGORITHM_ES384,
-            Algorithms::COSE_ALGORITHM_ES512,
-            Algorithms::COSE_ALGORITHM_RS256,
-            Algorithms::COSE_ALGORITHM_RS384,
-            Algorithms::COSE_ALGORITHM_RS512,
-            Algorithms::COSE_ALGORITHM_PS256,
-            Algorithms::COSE_ALGORITHM_PS384,
-            Algorithms::COSE_ALGORITHM_PS512,
-            Algorithms::COSE_ALGORITHM_ED256,
-            Algorithms::COSE_ALGORITHM_ED512,
-        ])->map(
-            fn($algorithm) => PublicKeyCredentialParameters::create('public-key', $algorithm)
-        )->toArray();
-
-        // Instantiate PublicKeyCredentialCreationOptions object
-        $pkCreationOptions =
-            PublicKeyCredentialCreationOptions::create(
-                $rpEntity,
-                $userEntity,
-                $challenge,
-                $supportedPublicKeyParams,
-                authenticatorSelection: AuthenticatorSelectionCriteria::create(),
-                attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
-                extensions: AuthenticationExtensionsClientInputs::createFromArray([
-                    'credProps' => true,
-                ])
-            );
-
-        $serializedOptions = $pkCreationOptions->jsonSerialize();
-
-        if (!isset($serializedOptions['excludeCredentials'])) {
-            // The JS side needs this, so let's set it up for success with an empty array
-            $serializedOptions['excludeCredentials'] = [];
-        }
-
-        // This library for some reason doesn't serialize the extensions object,
-        // so we'll do it manually
-        $serializedOptions['extensions'] = $serializedOptions['extensions']->jsonSerialize();
-
-        // Another thing we have to do manually for this to work the way we want to todo OR NOT??
-        // $serializedOptions['authenticatorSelection']['residentKey'] = AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED;
-
-        // It is important to store the user entity and the options object (e.g. in the session)
-        // for the next step. The data will be needed to check the response from the device.
-        $request->session()->flash(
-            self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY,
-            json_decode(json_encode($serializedOptions), true)
-        );
-
-        return $serializedOptions;
+        return $this->passkeyService->generateOptions($request);
     }
 
     /**
@@ -115,66 +33,22 @@ class RegistrationController extends Controller {
      * @throws Throwable
      * @throws ValidationException
      */
-    public function verify(Request $request, ServerRequestInterface $serverRequest): array {
+    public function verify(Request $request, ServerRequestInterface $serverRequest) {
         $userData = $request->validate(config('passkeys.registration_user_validation'));
 
-        // A repo of our public key credentials
-        $pkSourceRepo = new CredentialSourceRepository();
+        $response = $this->passkeyService->verify($request, $serverRequest);
 
-        $attestationManager = AttestationStatementSupportManager::create();
-        $attestationManager->add(NoneAttestationStatementSupport::create());
+        if ($response['verified']) {
+            $user = config('passkeys.user_model')::create(array_merge([
+                config('passkeys.username_column') => $request->input(config('passkeys.username_column')),
+            ], $userData));
 
-        // The validator that will check the response from the device
-        $responseValidator = AuthenticatorAttestationResponseValidator::create(
-            $attestationManager,
-            $pkSourceRepo,
-            null,
-            ExtensionOutputCheckerHandler::create()
-        );
+            Auth::login($user);
 
-        // A loader that will load the response from the device
-        $pkCredentialLoader = PublicKeyCredentialLoader::create(
-            AttestationObjectLoader::create($attestationManager)
-        );
-
-        $publicKeyCredential = $pkCredentialLoader->load(json_encode($request->all()));
-
-        $authenticatorAttestationResponse = $publicKeyCredential->response;
-
-        if (!$authenticatorAttestationResponse instanceof AuthenticatorAttestationResponse) {
-            throw ValidationException::withMessages([
-                config('passkeys.username_column') => 'Invalid response type',
-            ]);
+            return ['verified' => true];
         }
 
-        // Check the response from the device, this will
-        // throw an exception if the response is invalid.
-        // For the purposes of this demo, we are letting
-        // the exception bubble up so we can see what is
-        // going on.
-        $publicKeyCredentialSource = $responseValidator->check(
-            $authenticatorAttestationResponse,
-            PublicKeyCredentialCreationOptions::createFromArray(
-                $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
-            ),
-            $serverRequest,
-            config('passkeys.relying_party_ids')
-        );
-
-        // If we've gotten this far, the response is valid!
-
-        // Save the user and the public key credential source to the database
-        $user = config('passkeys.user_model')::create(array_merge([
-            config('passkeys.username_column') => $publicKeyCredentialSource->userHandle,
-        ], $userData));
-
-        $pkSourceRepo->saveCredentialSource($publicKeyCredentialSource);
-
-        Auth::login($user);
-
-        return [
-            'verified' => true,
-        ];
+        return ['verified' => false];
     }
 
 }

--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Misakstvanu\LaravelFortifyPasskeys\Services;
+
+use Cose\Algorithms;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+use Misakstvanu\LaravelFortifyPasskeys\CredentialSourceRepository;
+use Psr\Http\Message\ServerRequestInterface;
+use Random\RandomException;
+use Throwable;
+use Webauthn\AttestationStatement\AttestationObjectLoader;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensionsClientInputs;
+use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\Exception\InvalidDataException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialLoader;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+class PasskeyService {
+
+    const CREDENTIAL_CREATION_OPTIONS_SESSION_KEY = 'publicKeyCredentialCreationOptions';
+
+    /**
+     * @throws RandomException
+     */
+    public function generateOptions(Request $request, $user = null): array {
+        // Relying on Party Entity i.e. the application
+        $rpEntity = PublicKeyCredentialRpEntity::create(
+            config('app.name'),
+            parse_url(config('app.url'), PHP_URL_HOST),
+            null,
+        );
+
+        // User Entity
+        if ($user) {
+            $userEntity = PublicKeyCredentialUserEntity::create(
+                $user->email,
+                (string) $user->id,
+                $user->name,
+                null,
+            );
+        } else {
+            $userEntity = PublicKeyCredentialUserEntity::create(
+                $request->input(config('passkeys.username_column')),
+                $request->input(config('passkeys.username_column')),
+                $request->input(config('passkeys.username_column')),
+                null,
+            );
+        }
+
+        // Challenge (random binary string)
+        $challenge = random_bytes(16);
+
+        // List of supported public key parameters
+        $supportedPublicKeyParams = collect([
+            Algorithms::COSE_ALGORITHM_ES256,
+            Algorithms::COSE_ALGORITHM_ES256K,
+            Algorithms::COSE_ALGORITHM_ES384,
+            Algorithms::COSE_ALGORITHM_ES512,
+            Algorithms::COSE_ALGORITHM_RS256,
+            Algorithms::COSE_ALGORITHM_RS384,
+            Algorithms::COSE_ALGORITHM_RS512,
+            Algorithms::COSE_ALGORITHM_PS256,
+            Algorithms::COSE_ALGORITHM_PS384,
+            Algorithms::COSE_ALGORITHM_PS512,
+            Algorithms::COSE_ALGORITHM_ED256,
+            Algorithms::COSE_ALGORITHM_ED512,
+        ])->map(
+            fn($algorithm) => PublicKeyCredentialParameters::create('public-key', $algorithm)
+        )->toArray();
+
+        // Instantiate PublicKeyCredentialCreationOptions object
+        $pkCreationOptions =
+            PublicKeyCredentialCreationOptions::create(
+                $rpEntity,
+                $userEntity,
+                $challenge,
+                $supportedPublicKeyParams,
+                authenticatorSelection: AuthenticatorSelectionCriteria::create(),
+                attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+                extensions: AuthenticationExtensionsClientInputs::createFromArray([
+                    'credProps' => true,
+                ])
+            );
+
+        $serializedOptions = $pkCreationOptions->jsonSerialize();
+
+        if (!isset($serializedOptions['excludeCredentials'])) {
+            // The JS side needs this, so let's set it up for success with an empty array
+            $serializedOptions['excludeCredentials'] = [];
+        }
+
+        // This library for some reason doesn't serialize the extensions object,
+        // so we'll do it manually
+        $serializedOptions['extensions'] = $serializedOptions['extensions']->jsonSerialize();
+
+        // It is important to store the user entity and the options object (e.g. in the session)
+        // for the next step. The data will be needed to check the response from the device.
+        $request->session()->flash(
+            self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY,
+            json_decode(json_encode($serializedOptions), true)
+        );
+
+        return $serializedOptions;
+    }
+
+    /**
+     * @throws InvalidDataException
+     * @throws Throwable
+     * @throws ValidationException
+     */
+    public function verify(Request $request, ServerRequestInterface $serverRequest, $user = null): array {
+        // A repo of our public key credentials
+        $pkSourceRepo = new CredentialSourceRepository();
+
+        $attestationManager = AttestationStatementSupportManager::create();
+        $attestationManager->add(NoneAttestationStatementSupport::create());
+
+        // The validator that will check the response from the device
+        $responseValidator = AuthenticatorAttestationResponseValidator::create(
+            $attestationManager,
+            $pkSourceRepo,
+            null,
+            ExtensionOutputCheckerHandler::create()
+        );
+
+        // A loader that will load the response from the device
+        $pkCredentialLoader = PublicKeyCredentialLoader::create(
+            AttestationObjectLoader::create($attestationManager)
+        );
+
+        $publicKeyCredential = $pkCredentialLoader->load(json_encode($request->all()));
+
+        $authenticatorAttestationResponse = $publicKeyCredential->response;
+
+        if (!$authenticatorAttestationResponse instanceof AuthenticatorAttestationResponse) {
+            throw ValidationException::withMessages([
+                config('passkeys.username_column') => 'Invalid response type',
+            ]);
+        }
+
+        // Check the response from the device, this will
+        // throw an exception if the response is invalid.
+        // For the purposes of this demo, we are letting
+        // the exception bubble up so we can see what is
+        // going on.
+        $publicKeyCredentialSource = $responseValidator->check(
+            $authenticatorAttestationResponse,
+            PublicKeyCredentialCreationOptions::createFromArray(
+                $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
+            ),
+            $serverRequest,
+            config('passkeys.relying_party_ids')
+        );
+
+        // If we've gotten this far, the response is valid!
+
+        // Save the public key credential source to the database
+        if ($user) {
+            $publicKeyCredentialSource->userHandle = $user->{config('passkeys.username_column')};
+        } else {
+            $publicKeyCredentialSource->userHandle = $request->input(config('passkeys.username_column'));
+        }
+
+        $pkSourceRepo->saveCredentialSource($publicKeyCredentialSource);
+
+        return [
+            'verified' => true,
+        ];
+    }
+}


### PR DESCRIPTION
Refactor controllers to reduce code duplication by introducing a PasskeyService.

* **Add PasskeyService**:
  - Create `src/Services/PasskeyService.php` to handle common logic for generating options and verifying responses.
  - Implement `generateOptions` and `verify` methods in `PasskeyService`.

* **Update AddPasskeyController**:
  - Inject `PasskeyService` in the constructor.
  - Refactor `generateOptions` and `verify` methods to use `PasskeyService`.

* **Update RegistrationController**:
  - Inject `PasskeyService` in the constructor.
  - Refactor `generateOptions` and `verify` methods to use `PasskeyService`.

* **Update AuthenticationController**:
  - Inject `PasskeyService` in the constructor.
  - Refactor `verify` method to use `PasskeyService`.

