### PR TITLE
Fix login error related to credProps extension

### DIFF
--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -35,7 +35,7 @@ class AuthenticationController extends Controller {
             throw new ModelNotFoundException('User not found', 404, $e);
         }
 
-        return $this->passkeyService->generateOptions($request, $user);
+        return $this->passkeyService->generateOptions($request, $user, false);
     }
 
     /**

--- a/src/Controllers/RegistrationController.php
+++ b/src/Controllers/RegistrationController.php
@@ -25,7 +25,7 @@ class RegistrationController extends Controller {
      * @throws RandomException
      */
     public function generateOptions(Request $request): array {
-        return $this->passkeyService->generateOptions($request);
+        return $this->passkeyService->generateOptions($request, null, true);
     }
 
     /**


### PR DESCRIPTION
Update the `generateOptions` method in `PasskeyService` to conditionally include the `credProps` extension only for registration.

* **PasskeyService.php**
  - Add a parameter to the `generateOptions` method to indicate if it is for registration.
  - Conditionally include the `credProps` extension only for registration.
  - Ensure the `extensions` object is serialized only if it is for registration.

* **AuthenticationController.php**
  - Update the `generateOptions` method to call the `generateOptions` method in `PasskeyService` without the `credProps` extension.

* **RegistrationController.php**
  - Update the `generateOptions` method to call the `generateOptions` method in `PasskeyService` with the `credProps` extension.

