### PR TITLE
Fix login verification error message

### DIFF
--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -22,10 +22,16 @@ use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialLoader;
+use Webauthn\PublicKeyCredentialParameters;
 
 class PasskeyService {
 
     const CREDENTIAL_CREATION_OPTIONS_SESSION_KEY = 'publicKeyCredentialCreationOptions';
+    const CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY = 'publicKeyCredentialRequestOptions';
 
     /**
      * @throws RandomException
@@ -126,8 +132,14 @@ class PasskeyService {
         $attestationManager->add(NoneAttestationStatementSupport::create());
 
         // The validator that will check the response from the device
-        $responseValidator = AuthenticatorAttestationResponseValidator::create(
+        $attestationResponseValidator = AuthenticatorAttestationResponseValidator::create(
             $attestationManager,
+            $pkSourceRepo,
+            null,
+            ExtensionOutputCheckerHandler::create()
+        );
+
+        $assertionResponseValidator = AuthenticatorAssertionResponseValidator::create(
             $pkSourceRepo,
             null,
             ExtensionOutputCheckerHandler::create()
@@ -140,27 +152,31 @@ class PasskeyService {
 
         $publicKeyCredential = $pkCredentialLoader->load(json_encode($request->all()));
 
-        $authenticatorAttestationResponse = $publicKeyCredential->response;
+        $authenticatorResponse = $publicKeyCredential->response;
 
-        if (!$authenticatorAttestationResponse instanceof AuthenticatorAttestationResponse) {
+        if ($authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+            $publicKeyCredentialSource = $attestationResponseValidator->check(
+                $authenticatorResponse,
+                PublicKeyCredentialCreationOptions::createFromArray(
+                    $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
+                ),
+                $serverRequest,
+                config('passkeys.relying_party_ids')
+            );
+        } elseif ($authenticatorResponse instanceof AuthenticatorAssertionResponse) {
+            $publicKeyCredentialSource = $assertionResponseValidator->check(
+                $authenticatorResponse,
+                PublicKeyCredentialRequestOptions::createFromArray(
+                    $request->session()->get(self::CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY)
+                ),
+                $serverRequest,
+                config('passkeys.relying_party_ids')
+            );
+        } else {
             throw ValidationException::withMessages([
-                config('passkeys.username_column') => 'Invalid response type',
+                'error' => 'Invalid response type',
             ]);
         }
-
-        // Check the response from the device, this will
-        // throw an exception if the response is invalid.
-        // For the purposes of this demo, we are letting
-        // the exception bubble up so we can see what is
-        // going on.
-        $publicKeyCredentialSource = $responseValidator->check(
-            $authenticatorAttestationResponse,
-            PublicKeyCredentialCreationOptions::createFromArray(
-                $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
-            ),
-            $serverRequest,
-            config('passkeys.relying_party_ids')
-        );
 
         // If we've gotten this far, the response is valid!
 


### PR DESCRIPTION
Update `verify` method in `PasskeyService.php` to handle both `AttestationResponse` and `AssertionResponse` and throw a generic error message.

* Add necessary imports for `AuthenticatorAssertionResponse`, `AuthenticatorAssertionResponseValidator`, `PublicKeyCredentialRequestOptions`, and `PublicKeyCredentialParameters`.
* Add constant `CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY`.
* Update `verify` method to create `AuthenticatorAssertionResponseValidator`.
* Update `verify` method to handle both `AuthenticatorAttestationResponse` and `AuthenticatorAssertionResponse`.
* Remove association of error message with `config('passkeys.username_column')` and replace with a generic 'Invalid response type' message.

