### PR TITLE
Fix type errors in PasskeyService and Controllers

### DIFF
--- a/src/Controllers/AddPasskeyController.php
+++ b/src/Controllers/AddPasskeyController.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Random\RandomException;
 use Throwable;
 use Webauthn\Exception\InvalidDataException;
+use Webauthn\PublicKeyCredentialRequestOptions;
 
 class AddPasskeyController extends Controller {
 
@@ -37,7 +38,9 @@ class AddPasskeyController extends Controller {
     public function verify(Request $request, ServerRequestInterface $serverRequest): array
     {
         $user = Auth::user();
-        return $this->passkeyService->verify($request, $serverRequest, $user);
+        $publicKeyCredentialSource = $this->passkeyService->verify($request, $serverRequest, $user);
+
+        return $publicKeyCredentialSource;
     }
 
 }

--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Random\RandomException;
 use Throwable;
 use Webauthn\Exception\InvalidDataException;
+use Webauthn\PublicKeyCredentialRequestOptions;
 
 class AuthenticationController extends Controller {
 

--- a/src/Controllers/RegistrationController.php
+++ b/src/Controllers/RegistrationController.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Random\RandomException;
 use Throwable;
 use Webauthn\Exception\InvalidDataException;
+use Webauthn\PublicKeyCredentialRequestOptions;
 
 class RegistrationController extends Controller {
 

--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -27,6 +27,7 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 class PasskeyService {
 
     const CREDENTIAL_CREATION_OPTIONS_SESSION_KEY = 'publicKeyCredentialCreationOptions';
+    const CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY = 'publicKeyCredentialRequestOptions';
 
     /**
      * @throws RandomException
@@ -157,7 +158,7 @@ class PasskeyService {
         $publicKeyCredentialSource = $responseValidator->check(
             $authenticatorAttestationResponse,
             PublicKeyCredentialRequestOptions::createFromArray(
-                $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
+                $request->session()->get(self::CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY)
             ),
             $serverRequest,
             config('passkeys.relying_party_ids')

--- a/src/Services/PasskeyService.php
+++ b/src/Services/PasskeyService.php
@@ -22,6 +22,7 @@ use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\PublicKeyCredentialRequestOptions;
 
 class PasskeyService {
 
@@ -155,7 +156,7 @@ class PasskeyService {
         // going on.
         $publicKeyCredentialSource = $responseValidator->check(
             $authenticatorAttestationResponse,
-            PublicKeyCredentialCreationOptions::createFromArray(
+            PublicKeyCredentialRequestOptions::createFromArray(
                 $request->session()->get(self::CREDENTIAL_CREATION_OPTIONS_SESSION_KEY)
             ),
             $serverRequest,


### PR DESCRIPTION
Resolve type errors involving `assertionResponseValidator` and `PublicKeyCredentialRequestOptions`.

* Update `src/Services/PasskeyService.php` to use `PublicKeyCredentialRequestOptions` instead of `PublicKeyCredentialCreationOptions` in the `verify` method.
* Add `use Webauthn\PublicKeyCredentialRequestOptions;` in `src/Controllers/AuthenticationController.php`, `src/Controllers/RegistrationController.php`, and `src/Controllers/AddPasskeyController.php`.
* Update `src/Controllers/AddPasskeyController.php` to return `$publicKeyCredentialSource` in the `verify` method.

