### PR TITLE
Update PasskeyService to handle both attestation and assertion for passkey verification

### DIFF
--- a/src/Controllers/AddPasskeyController.php
+++ b/src/Controllers/AddPasskeyController.php
@@ -37,7 +37,13 @@ class AddPasskeyController extends Controller {
     public function verify(Request $request, ServerRequestInterface $serverRequest): array
     {
         $user = Auth::user();
-        return $this->passkeyService->verify($request, $serverRequest, $user);
+        $response = $this->passkeyService->verify($request, $serverRequest, $user);
+
+        if ($response['verified']) {
+            return ['verified' => true];
+        }
+
+        return ['verified' => false];
     }
 
 }


### PR DESCRIPTION
Update the `verify` method in `PasskeyService` to handle both attestation and assertion responses for creating and verifying passkeys.

* **PasskeyService.php**
  - Add imports for `AuthenticatorAssertionResponse`, `AuthenticatorAssertionResponseValidator`, and `PublicKeyCredentialRequestOptions`.
  - Add a constant for `CREDENTIAL_REQUEST_OPTIONS_SESSION_KEY`.
  - Create `AuthenticatorAssertionResponseValidator`.
  - Update the `verify` method to differentiate between attestation and assertion responses.
  - Add logic to handle assertion response validation and user authentication.
  - Save the public key credential source to the database for attestation responses.
  - Return user handle for assertion responses.

* **AddPasskeyController.php**
  - Update the `verify` method to handle the response from `PasskeyService`.
  - Return `verified` status based on the response from `PasskeyService`.

